### PR TITLE
Fix: Correct n8n icon path

### DIFF
--- a/nodes/Contentdrips/Contentdrips.node.ts
+++ b/nodes/Contentdrips/Contentdrips.node.ts
@@ -13,7 +13,7 @@ export class Contentdrips implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Contentdrips',
 		name: 'contentdrips',
-		icon: 'file:contentdrips.svg',
+		icon: 'file:contentdrips_icon.svg',
 		group: ['transform'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',


### PR DESCRIPTION
The n8n icon was not displaying due to an incorrect file path in the node definition. This commit corrects the path to ensure the icon is displayed correctly.